### PR TITLE
Improve build/test reliability.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,31 +1,32 @@
 source 'https://rubygems.org'
+
 source "https://gem.fury.io/jdickey/" do
-  gem 'prolog-use_cases', '~> 0.10'
+  gem 'prolog-use_cases', '~> 0.10', '>= 0.10.0'
 end
 
-gem 'sinatra', '~> 1.4', '>= 1.4.7'
-gem 'sequel', '~> 4.35', '>= 4.35.0'
-gem 'rake', '~> 11.2', '>= 11.2.2'
-gem 'guard', '~> 2.14', '>= 2.14.0'
 gem 'foreman', '~> 0.82', '>= 0.82.0'
-gem 'sqlite3', '~> 1.3', '>= 1.3.11'
+gem 'guard', '~> 2.14', '>= 2.14.0'
+gem 'pg', '~> 0.18', '>= 0.18.4'
+gem 'rake', '~> 11.2', '>= 11.2.2'
+gem 'sequel', '~> 4.35', '>= 4.35.0'
 gem 'shotgun', '~> 0.9', '>= 0.9.1'
-gem 'pg'
+gem 'sinatra', '~> 1.4', '>= 1.4.7'
+gem 'sqlite3', '~> 1.3', '>= 1.3.11'
 
 group :development do
 #  gem 'ruby_gntp', '~> 0.3', '>= 0.3.4'
 end
 
 group :test do
-  gem 'rack', '~> 1.6', '>= 1.6.4'
-  gem 'rack-test', '~> 0.6', '>= 0.6.3'
-  gem 'minitest', '~> 5.9', '>= 5.9.0'
   gem 'capybara', '~> 2.7', '>= 2.7.1'
   gem 'capybara_minitest_spec', '~> 1.0', '>= 1.0.5'
-  gem 'guard-minitest', '~> 2.4', '>= 2.4.5'
-  gem 'poltergeist', '~> 1.9', '>= 1.9.0'
-  gem 'rubocop', '0.35.1'
-  gem 'reek', '3.7'
-  gem 'flay', '2.6'
+  gem 'flay', '~> 2.8', '>= 2.8.0'
   gem 'flog', '~> 4.3', '>= 4.3.2'
+  gem 'guard-minitest', '~> 2.4', '>= 2.4.5'
+  gem 'minitest', '~> 5.9', '>= 5.9.0'
+  gem 'poltergeist', '~> 1.9', '>= 1.9.0'
+  gem 'rack', '~> 1.6', '>= 1.6.4'
+  gem 'rack-test', '~> 0.6', '>= 0.6.3'
+  gem 'reek', '~> 4.0', '>= 4.0.5'
+  gem 'rubocop', '~> 0.40', '>= 0.40.0'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 require 'rake/testtask'
 require 'rubocop/rake_task'
 require 'reek/rake/task'
+require 'flay'
 require 'flay_task'
 require 'flog'
 require 'flog_task'
@@ -51,5 +52,3 @@ end
 
 task(:default).clear
 task default: [:spec, :rubocop, :reek, :flay, :flog, :feature]
-
-

--- a/bin/resetdb
+++ b/bin/resetdb
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+if [[ ! -n $1 ]]; then
+  echo "MUST specify database name and database user as parameters in order"
+  exit 1
+fi
+
+if [[ ! -n $2 ]]; then
+  echo "MUST specify database name and database user as parameters in order"
+  exit 2
+fi
+
+DBNAME=$1
+DBUSER=$2
+
+printf "Setting up Postgres database (1/4): dropping existing DB\r"
+dropdb --if-exists $DBNAME
+printf "Setting up Postgres database (2/4): dropping existing DB user\r"
+dropuser $DBUSER
+printf "Setting up Postgres database (3/4): recreating DB role\r"
+createuser -dl $DBUSER
+printf "Setting up Postgres database (4/4): recreating database\r"
+createdb --username=$DBUSER $DBNAME
+printf "%-80s\n" "Setup of Postgres database completed."

--- a/bin/setup
+++ b/bin/setup
@@ -3,6 +3,8 @@
 # IFS=$'\n\t'
 # set -vx
 APPNAME='sinatratest'
+DBNAME="sinatratest_db"
+DBUSER="sinatratest_db"
 
 # Do Stuff.
 
@@ -17,6 +19,10 @@ if [[ -d $RBENV_ROOT ]]
 then
   rbenv rehash
 fi
+
+# Setup Postgres database and user
+
+bin/resetdb $DBNAME $DBUSER
 
 # Install/update binstubs, enabling 'bin/rake' rather than 'bundle exec rake'.
 

--- a/lib/sinatratest.rb
+++ b/lib/sinatratest.rb
@@ -5,7 +5,8 @@ require 'pg'
 require 'prolog/use_cases/summarise_content'
 require_relative '../config/environment.rb'
 
-DB = Sequel.postgres('sinatratest_db', user: 'sinatratest_db', host: 'localhost', port: 5432)
+DB = Sequel.postgres('sinatratest_db', user: 'sinatratest_db',
+                                       host: 'localhost', port: 5432)
 
 DB.create_table? :articles do
   primary_key :id
@@ -36,18 +37,19 @@ class ArticleRepo
 
   private
 
+  attr_reader :articles
+
   def keywords_to_a
-    @articles.each do |art|
-      keyword_split(art)
+    @articles.each { |article| Internals.keyword_split article }
+  end
+
+  # Methods neither affecting nor affected by instance state.
+  module Internals
+    def self.keyword_split(article)
+      oldkeywords = article.keywords
+      article.keywords = oldkeywords.split(/,/).map(&:strip)
     end
   end
-
-  def keyword_split(article)
-    oldkeywords = article.keywords
-    article.keywords = oldkeywords.split(/,/).map(&:strip)
-  end
-
-  attr_reader :articles
 end
 
 get '/' do

--- a/spec/sinatratest_spec.rb
+++ b/spec/sinatratest_spec.rb
@@ -1,8 +1,9 @@
+
 require_relative 'spec_helper'
 
-describe 'my app' do
-  it 'should return a UI' do
+describe 'the main application' do
+  it 'should respond to the HTTP GET method for the root path' do
     get '/'
-    last_response.ok?
+    expect(last_response).must_be :ok?
   end
 end


### PR DESCRIPTION
This is a multiple-step process.

The initial commit locked down the Gem versions in the `Gemfile` and made some relatively minor code and spec changes to bring the existing code into greater compliance with the updated tools.

Next up is to make the feature spec reliable and make the overall spec suite idempotent (and thus repeatable at will). Specs _must not_ change persistent state; nor should they assume that the state of the application on startup is in a known state when no verification or enforcement of that exists. (See Issue #2).

Laziness is a virtue only when it prods the creation of artefacts and processes that induce a _net reduction_ in future work to achieve a given goal. It’s easy to lose sight of that.
